### PR TITLE
Bump Beaver to version 33.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An Ansible role for installing [Beaver](https://github.com/josegonzalez/python-b
 - `beaver_redis_url` - A Redis URL for Beaver to publish messages (default: `redis://localhost:6379/0`)
 - `beaver_redis_namespace` - A namespace within Redis for Beaver to publish messages (default: `logstash`)
 - `beaver_logstash_version` - Logstash 1.2 introduced a JSON schema change, so if you're using > 1.0, this needs to be set to `1` (default: `1`)
+- `beaver_docutils_version` - Version of `docutils` dependency for Beaver (default: `0.12`)
 - `beaver_log` - Beaver log path (default: `/var/log/beaver.log`)
 - `beaver_log_rotate_count` - Beaver log rotation count (default: `5`)
 - `beaver_log_rotate_interval` - Beaver log rotation interval (default: `daily`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,13 @@
 ---
-beaver_version: "31"
+beaver_version: "33.0.0"
 beaver_conf_dir: /etc/beaver
 beaver_data_dir: /var/lib/beaver
 
 beaver_redis_url: "redis://localhost:6379/0"
 beaver_redis_namespace: "logstash"
 beaver_logstash_version: 1
+
+beaver_docutils_version: "0.12"
 
 beaver_log: /var/log/beaver.log
 beaver_log_rotate_count: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,9 @@
         shell=/bin/false
         state=present
 
+- name: Install Python Docutils
+  pip: name=docutils version={{ beaver_docutils_version }} state=present
+
 - name: Install Beaver
   pip: name=beaver version={{ beaver_version }} state=present
 


### PR DESCRIPTION
This changeset bumps the default version of Beaver to 33.0.0. Mysteriously, `docutils` is required as a dependency for Beaver to work, yet it is not installed automatically through the pip installation process.
