### PR TITLE
Fix python-daemon dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An Ansible role for installing [Beaver](https://github.com/josegonzalez/python-b
 - `beaver_redis_url` - A Redis URL for Beaver to publish messages (default: `redis://localhost:6379/0`)
 - `beaver_redis_namespace` - A namespace within Redis for Beaver to publish messages (default: `logstash`)
 - `beaver_logstash_version` - Logstash 1.2 introduced a JSON schema change, so if you're using > 1.0, this needs to be set to `1` (default: `1`)
-- `beaver_docutils_version` - Version of `docutils` dependency for Beaver (default: `0.12`)
+- `beaver_dependencies` - A list of Beaver dependencies that do not install correctly on their own (default: `[ docutils, python-daemon ]`)
 - `beaver_log` - Beaver log path (default: `/var/log/beaver.log`)
 - `beaver_log_rotate_count` - Beaver log rotation count (default: `5`)
 - `beaver_log_rotate_interval` - Beaver log rotation interval (default: `daily`)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,9 @@ beaver_redis_url: "redis://localhost:6379/0"
 beaver_redis_namespace: "logstash"
 beaver_logstash_version: 1
 
-beaver_docutils_version: "0.12"
+beaver_dependencies:
+  - { name: "docutils", version: "0.12" }
+  - { name: "python-daemon", version: "2.0.2" }
 
 beaver_log: /var/log/beaver.log
 beaver_log_rotate_count: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,11 @@
         shell=/bin/false
         state=present
 
-- name: Install Python Docutils
-  pip: name=docutils version={{ beaver_docutils_version }} state=present
+- name: Install Beaver dependencies
+  pip: name={{ item.name }}
+       version={{ item.version }}
+       state=present
+  with_items: beaver_dependencies
 
 - name: Install Beaver
   pip: name=beaver version={{ beaver_version }} state=present


### PR DESCRIPTION
This changeset fixes the `python-daemon` `setup.py` dependency installation by manually installing `python-daemon` before Beaver.

See also: https://lists.alioth.debian.org/pipermail/python-daemon-devel/2015-January/000111.html
