### PR TITLE
Bump Beaver version to 33.3.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-beaver_version: "33.0.0"
+beaver_version: "33.3.0"
 beaver_conf_dir: /etc/beaver
 beaver_data_dir: /var/lib/beaver
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
        version={{ item.version }}
        state=present
   with_items: beaver_dependencies
+  when: beaver_version | version_compare('33.0.0', '<=')
 
 - name: Install Beaver
   pip: name=beaver version={{ beaver_version }} state=present


### PR DESCRIPTION
This changeset bumps the version of Beaver that is installed by default to `33.3.0`. Version `33.1.0` was the first version to fix the `python-daemon` dependency bug that forced us to manually install Beaver dependencies. That Ansible task is now guarded by a version comparison.
