### PR TITLE
Fix Beaver logrotate configuration to avoid lost file handles

### DIFF
--- a/templates/logrotate_beaver.j2
+++ b/templates/logrotate_beaver.j2
@@ -3,5 +3,8 @@
   {{ beaver_log_rotate_interval }}
   compress
   missingok
+  postrotate
+    restart beaver
+  endscript
   notifempty
 }


### PR DESCRIPTION
`logrotate` runs daily to rotate the Beaver logs in a way that causes Beaver to think that they've been deleted. In order to resolve this issue, after a rotate occurs, a Beaver daemon restart is triggered.
