### PR TITLE
Make use of YAML role spec format; replace touch usage

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -8,7 +8,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.redis") || File.symlink?("roles/azavea.redis")) ||
   !(File.directory?("roles/azavea.logstash") || File.symlink?("roles/azavea.logstash")) ||
   !(File.directory?("roles/azavea.pip") || File.symlink?("roles/azavea.pip"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,3 +1,0 @@
-azavea.redis,0.1.0
-azavea.logstash,0.1.0
-azavea.pip,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,6 @@
+- src: azavea.redis
+  version: 0.1.0
+- src: azavea.logstash
+  version: 0.1.0
+- src: azavea.pip
+  version: 0.1.0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,8 +30,7 @@
     - Restart Beaver
 
 - name: Touch log file if it does not exist
-  command: touch {{ beaver_log }}
-           creates={{ beaver_log }}
+  copy: content="" dest="{{ beaver_log }}" force=no
 
 - name: Set log file permissions
   file: path={{ beaver_log }} owner=beaver group=beaver mode=0644


### PR DESCRIPTION
The is an attempt to silence deprecation warnings in Ansible 2.0. In addition to the YAML role specification format updates, I changed an instance of the command module/touch with the copy module.

---

**Testing**

``` bash
$ cd examples
$ rm -rf roles/azavea.logstash roles/azavea.pip roles/azavea.redis
$ vagrant destroy -f && vagrant up
```
