### PR TITLE
Fix installation of Beaver by updating version to 36.2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-beaver_version: "33.3.0"
+beaver_version: "36.2.0"
 beaver_conf_dir: /etc/beaver
 beaver_data_dir: /var/lib/beaver
 


### PR DESCRIPTION
Older versions of Beaver depend on the mosquitto package.
After moving to the Eclipse Foundation mosquitto was renamed to paho-mqtt and all
versions of mosquitto seem to have been pulled from PyPi.

Because of that, 36.2.0 (the most recent) is the only version of Beaver
that can actually be installed.
