### PR TITLE
Remove explicit dependency install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,10 +7,6 @@ beaver_redis_url: "redis://localhost:6379/0"
 beaver_redis_namespace: "logstash"
 beaver_logstash_version: 1
 
-beaver_dependencies:
-  - { name: "docutils", version: "0.12" }
-  - { name: "python-daemon", version: "2.0.2" }
-
 beaver_log: /var/log/beaver.log
 beaver_log_rotate_count: 5
 beaver_log_rotate_interval: daily

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,13 +6,6 @@
         shell=/bin/false
         state=present
 
-- name: Install Beaver dependencies
-  pip: name={{ item.name }}
-       version={{ item.version }}
-       state=present
-  with_items: beaver_dependencies
-  when: beaver_version | version_compare('33.0.0', '<=')
-
 - name: Install Beaver
   pip: name=beaver version={{ beaver_version }} state=present
 


### PR DESCRIPTION
Given that we are forced to start from a minimum version of 36.2.0 due to the removal of Mosquito, I think it also makes sense to drop backward compatibility for versions of Beaver <= 33.0.0 (required prior installation of `docutils` and `python-daemon`).
